### PR TITLE
Changed server default port to 3001

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -10,7 +10,7 @@ const env = process.env.NODE_ENV || 'dev'; // defaults to dev environment if not
 
 const dev = {
   app: {
-    port: parseInt(process.env.DEV_APP_PORT) || 3000
+    port: parseInt(process.env.DEV_APP_PORT) || 3001
   },
   db: {
     host: process.env.DEV_DB_HOST || 'localhost',
@@ -21,7 +21,7 @@ const dev = {
 };
 const test = {
   app: {
-    port: parseInt(process.env.TEST_APP_PORT) || 3000
+    port: parseInt(process.env.TEST_APP_PORT) || 3001
   },
   db: {
     host: process.env.TEST_DB_HOST || 'localhost',


### PR DESCRIPTION
When setting up the back end api I noticed I had the wrong default port set up for the back end server.  This fix fixes that issue.