### PR TITLE
Changes production to run wss protocol, not ws.

### DIFF
--- a/client/src/utils/setSocketConnection.js
+++ b/client/src/utils/setSocketConnection.js
@@ -3,15 +3,17 @@ import { DEVELOPMENT_SERVER_PORT } from "../constants";
 let socket;
 
 // set websocket server port to appropriate value depending on environment
-let port;
+let port, protocol;
 if (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test") {
     port = process.env.PORT || DEVELOPMENT_SERVER_PORT;
+    protocol = "ws";
 } else {
     port = window.location.port;
+    protocol = "wss";
 }
 
 const setSocketConnection = token => {
-    socket = io(`ws://localhost:${port}`, {
+    socket = io(`${protocol}://localhost:${port}`, {
         transports: ["websocket"],
         query: {
             token: token


### PR DESCRIPTION
Implements fix for running ws in production.  Heroku is running https protocol and websocket must run in wss mode in order to work.